### PR TITLE
Fix compile-problem with gcc-7.2 and add -fopenmp flags

### DIFF
--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -10,6 +10,11 @@ FILE(GLOB cpp_sources_fourier RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} fourier/*.cpp
 # Set up the compilation of those files into a shared library
 add_library(tprf_c ${cpp_sources} ${cpp_sources_lattice} ${cpp_sources_fourier})
 
+# We are using openmp
+target_compile_options(tprf_c PUBLIC -fopenmp)
+target_link_libraries(tprf_c PUBLIC "-fopenmp")
+# FIXME New cmake version allow: target_link_options(tprf_c PUBLIC -fopenmp)
+
 # This library should be linked to all libraries against which TRIQS is linked
 target_link_libraries(tprf_c PUBLIC triqs)
 

--- a/c++/channel_grouping.hpp
+++ b/c++/channel_grouping.hpp
@@ -37,7 +37,7 @@ public:
   Channel_t channel = C;
 
   inline memory_layout_t<6> memory_layout() const;
-  inline matrix_view<scalar_t> matrix_view(array_view<scalar_t, 6> arr) const;
+  inline triqs::arrays::matrix_view<scalar_t> matrix_view(array_view<scalar_t, 6> arr) const;
 };
 
 // ----------------------------------------------------
@@ -64,7 +64,7 @@ channel_grouping<Channel_t::PH>::memory_layout() const {
 }
 
 template <>
-inline matrix_view<scalar_t> channel_grouping<Channel_t::PH>::matrix_view(
+inline triqs::arrays::matrix_view<scalar_t> channel_grouping<Channel_t::PH>::matrix_view(
     array_view<scalar_t, 6> arr) const {
   return make_matrix_view(group_indices_view(arr, {0, 2, 3}, {1, 5, 4}));
 }
@@ -83,7 +83,7 @@ channel_grouping<Channel_t::PH_bar>::memory_layout() const {
 }
 
 template <>
-inline matrix_view<scalar_t> channel_grouping<Channel_t::PH_bar>::matrix_view(
+inline triqs::arrays::matrix_view<scalar_t> channel_grouping<Channel_t::PH_bar>::matrix_view(
     array_view<scalar_t, 6> arr) const {
   return make_matrix_view(group_indices_view(arr, {0, 2, 5}, {1, 4, 3}));
 }


### PR DESCRIPTION
This PR resolves two minor build issues. 

- We fully specify `triqs::arrays::matrix_view` in the channel_grouping.hpp header to fix the following gcc-7.2 compilation error

```
In file included from /home/ipht/nwentzel/Coding/tprf/c++/linalg.hpp:29:0,
                 from /home/ipht/nwentzel/Coding/tprf/c++/linalg.cpp:22:
/home/ipht/nwentzel/Coding/tprf/c++/channel_grouping.hpp:40:73: error: declaration of ‘triqs::arrays::matrix_view<std::complex<double>, void, false, false> tprf::channel_grouping<C>::matrix_view(triqs::arrays::array_view<std::complex<double>, 6, void, false, false>) const’
 [-fpermissive]
   inline matrix_view<scalar_t> matrix_view(array_view<scalar_t, 6> arr) const;
                                                                         ^~~~~
In file included from /home/ipht/nwentzel/opt/triqs/include/triqs/arrays.hpp:28:0,
                 from /home/ipht/nwentzel/Coding/tprf/c++/linalg.hpp:23,
                 from /home/ipht/nwentzel/Coding/tprf/c++/linalg.cpp:22:
/home/ipht/nwentzel/opt/triqs/include/triqs/arrays/matrix.hpp:57:11: error: changes meaning of ‘matrix_view’ from ‘class triqs::arrays::matrix_view<std::complex<double>, void, false, false>’ [-fpermissive]
     class matrix_view : Tag::matrix_view, TRIQS_CONCEPT_TAG_NAME(MutableMatrix), public IMPL_TYPE {
```

- We add the `-fopenmp` flag both as a compile and linktime to the PUBLIC interface of the tprf_c cmake target.