### PR TITLE
Eliashberg fft

### DIFF
--- a/c++/lattice/eliashberg.cpp
+++ b/c++/lattice/eliashberg.cpp
@@ -75,51 +75,76 @@ gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk,
   return delta_wk_out;
 }
 
-gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk,
-                       gk_iw_vt delta_wk) {
+std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_and_constant(chi_wk_vt Gamma_pp){
 
   auto _ = all_t{};
-
-  auto [wmesh, kmesh] = delta_wk.mesh();
-  auto gamma_wmesh = std::get<0>(Gamma_pp.mesh());
-
-  if (2*wmesh.size() > gamma_wmesh.size())
-      TRIQS_RUNTIME_ERROR << "The size of the Matsubara frequency mesh of Gamma"
-          " (" << gamma_wmesh.size() << ") must be atleast TWICE the size of the mesh of Delta (" <<
-          wmesh.size() << ").";
-
-  auto F_wk = eliashberg_g_delta_g_product(g_wk, delta_wk);
-  auto F_tr = make_gf_from_fourier<0, 1>(F_wk);
-
+  auto [wmesh, kmesh] = Gamma_pp.mesh();
+    
   // Fit infinite frequency value
   auto Gamma_pp_dyn = make_gf(Gamma_pp);
 
-  auto Gamma_const_k = make_gf(kmesh, Gamma_pp.target());
+  chi_k_vt Gamma_pp_const_k = make_gf(kmesh, Gamma_pp.target());
 
   for (const auto k : kmesh) {
     auto Gamma_w = Gamma_pp[_, k];
     auto [tail, err] = fit_tail(Gamma_w);
     for (auto [a, b, c, d] : Gamma_pp.target_indices())
-      Gamma_const_k[k](a, b, c, d) = tail(0, a, b, c, d);
-    for( const auto w : gamma_wmesh ) Gamma_pp_dyn[w, k] = Gamma_pp[w, k] - Gamma_const_k[k];
+      Gamma_pp_const_k[k](a, b, c, d) = tail(0, a, b, c, d);
+    for( const auto w : wmesh ) Gamma_pp_dyn[w, k] = Gamma_pp[w, k] - Gamma_pp_const_k[k];
   }
+
+    return {Gamma_pp_dyn, Gamma_pp_const_k};
+}
+
+
+gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp,
+                                gk_iw_vt g_wk, gk_iw_vt delta_wk) {
+
+  auto _ = all_t{};
+
+  auto F_wk = eliashberg_g_delta_g_product(g_wk, delta_wk);
+  auto F_tr = make_gf_from_fourier<0, 1>(F_wk);
+
+  auto [Gamma_pp_dyn, Gamma_pp_const_k] = split_into_dynamic_and_constant(Gamma_pp);
 
   auto Gamma_pp_tr = make_gf_from_fourier<0, 1>(Gamma_pp_dyn);
 
-  auto delta_tr_out = make_gf(Gamma_pp_tr.mesh(), delta_wk.target());
+  auto delta_tr_out = make_gf(F_tr.mesh(), delta_wk.target());
   delta_tr_out *= 0.;
 
-  auto [F_tmesh, F_rmesh] = F_tr.mesh();
-  double beta = F_tmesh.domain().beta;
-  
   for (const auto [t, r] : delta_tr_out.mesh()) {
-    auto F_t = F_tr[_, -r];
     for (auto [A, a, b, B] : Gamma_pp.target_indices())
-      delta_tr_out[t, r](a, b) = Gamma_pp[t, r](A, a, b, B) * F_t(beta - t)(A, B);
+      delta_tr_out[t, r](a, b) += -Gamma_pp_tr(t, r)(A, a, b, B) * F_tr(t, r)(A, B);
   }
   
   auto delta_wk_out = make_gf_from_fourier<0, 1>(delta_tr_out);
+
+
+  auto F_k = make_gf(Gamma_pp_const_k.mesh(), delta_wk.target());
+  F_k *= 0.;
+
+  for (const auto [w, k] : F_wk.mesh()) {
+      for (auto [a, b] : delta_wk.target_indices())
+          F_k[k](a, b) += F_wk[w, k](a, b);
+  }
+
+  auto F_r = make_gf_from_fourier<0>(F_k);
+  auto Gamma_pp_const_r = make_gf_from_fourier<0>(Gamma_pp_const_k);
   
+  auto delta_r_out = make_gf(F_r.mesh(), delta_wk.target());
+  delta_r_out *= 0.;
+
+  for (const auto r : delta_r_out.mesh()) {
+    for (auto [A, a, b, B] : Gamma_pp.target_indices())
+        delta_r_out[r](a, b) += -Gamma_pp_const_r(r)(A, a, b, B) * F_r(r)(A, B);
+  }
+
+  auto delta_k_out = make_gf_from_fourier<0>(delta_r_out);
+  delta_k_out *= 1. / std::get<0>(delta_wk.mesh()).domain().beta;
+
+  for (const auto [w , k]: delta_wk_out.mesh())
+      delta_wk_out[w, k] += delta_k_out[k];
+
   return delta_wk_out;
 }
   

--- a/c++/lattice/eliashberg.hpp
+++ b/c++/lattice/eliashberg.hpp
@@ -31,13 +31,13 @@ namespace tprf {
 
      .. math::
          \Delta^{(out)}_{\bar{a}\bar{b}}(\mathbf{k},i\nu) =  -\frac{1}{N_k \beta}\sum_{\mathbf{k}'} \sum_{i\nu'}
-	 \Gamma_{A\bar{a}\bar{b}B}(\mathbf{k}-\mathbf{k}', i\nu - i\nu')
+	 \Gamma_{A\bar{a}B\bar{b}}(\mathbf{k}-\mathbf{k}', i\nu - i\nu')
 	 \\ \times
 	 G_{A\bar{c}}(\mathbf{k}', i\nu')
 	 \Delta_{\bar{c}\bar{d}}(\mathbf{k}', i\nu')
 	 G_{B\bar{d}}(-\mathbf{k}', -i\nu')
 
-     @param chi_pp particle-particle vertex :math:`\Gamma^{(pp)}_{a\bar{b}\bar{c}d}(\mathbf{k}, i\nu_n)`
+     @param chi_pp particle-particle vertex :math:`\Gamma^{(pp)}_{a\bar{b}c\bar{d}}(\mathbf{k}, i\nu_n)`
      @param g_kw single particle Green's function :math:`G_{a\bar{b}}(\mathbf{k}, i\nu_n)`
      @param delta_kw pairing self-energy :math:`\Delta_{\bar{a}\bar{b}}(\mathbf{k}, i\nu_n)`
      @return Gives the result of the product :math:`\Delta^{(out)} \sim \Gamma^{(pp)}GG \Delta`
@@ -45,9 +45,55 @@ namespace tprf {
   */
 
   gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
-  gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
+
+ /** Linearized Eliashberg product via FFT
+
+     Computes the product
+
+     .. math::
+         \Delta^{(out)}_{\bar{a}\bar{b}}(\mathbf{k},i\nu) =  -\frac{1}{N_k \beta}\sum_{\mathbf{k}'} \sum_{i\nu'}
+	 \Gamma_{A\bar{a}B\bar{b}}(\mathbf{k}-\mathbf{k}', i\nu - i\nu')
+	 \\ \times
+	 G_{A\bar{c}}(\mathbf{k}', i\nu')
+	 \Delta_{\bar{c}\bar{d}}(\mathbf{k}', i\nu')
+	 G_{B\bar{d}}(-\mathbf{k}', -i\nu')\,,
+
+     by taking advantage of the convolution theorem.
+
+     We therefore first calculate
+
+     .. math::
+        \Delta^{(out)}_{\bar{a}\bar{b}}(\mathbf{r}, \tau) = 
+	 -\Gamma_{A\bar{a}B\bar{b}}(\mathbf{r}, \tau) F_{AB}(\mathbf{r}, \tau) \,,
+
+     where 
+
+     .. math::
+        F_{AB}(\mathbf{r}, \tau)  = 
+        \mathcal{F}\big(G_{A\bar{c}}(\mathbf{k}', i\nu')
+	 \Delta_{\bar{c}\bar{d}}(\mathbf{k}', i\nu')
+	 G_{B\bar{d}}(-\mathbf{k}', -i\nu')\big)\,.
+
+     Then we Fourier transform 
+
+     .. math::
+          \Delta^{(out)}_{\bar{a}\bar{b}}(\mathbf{k},i\nu) = 
+          \mathcal{F}\big(\Delta^{(out)}_{\bar{a}\bar{b}}(\mathbf{r}, \tau)\big)\,,
+
+    to get the same result, but with far less computational effort.
+
+     @param chi_rt dynamic part of the particle-particle vertex :math:`\Gamma^{(pp)}_{a\bar{b}c\bar{d}}(\mathbf{r}, \tau)`
+     @param chi_r constant part of the particle-particle vertex :math:`\Gamma^{(pp)}_{a\bar{b}c\bar{d}}(\mathbf{r})`
+     @param g_kw single particle Green's function :math:`G_{a\bar{b}}(\mathbf{k}, i\nu_n)`
+     @param delta_kw pairing self-energy :math:`\Delta_{\bar{a}\bar{b}}(\mathbf{k}, i\nu_n)`
+     @return Gives the result of the product :math:`\Delta^{(out)} \sim \Gamma^{(pp)}GG \Delta`
+
+  */
+
+  gk_iw_t eliashberg_product_fft(chi_tr_vt Gamma_pp_dyn_tr, chi_r_vt Gamma_pp_const_r, gk_iw_vt g_wk, gk_iw_vt delta_wk);
   gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk);
-  std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_and_constant(chi_wk_vt Gamma_pp);
+  std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_wk_and_constant_k(chi_wk_vt Gamma_pp);
+  std::tuple<chi_tr_vt, chi_r_vt> dynamic_and_constant_to_tr(chi_wk_vt Gamma_pp_dyn_wk, chi_k_vt Gamma_pp_const_k);
 
  /** Gamma particle-particle singlet
 

--- a/c++/lattice/eliashberg.hpp
+++ b/c++/lattice/eliashberg.hpp
@@ -45,6 +45,8 @@ namespace tprf {
   */
 
   gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
+  gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
+  gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk);
 
  /** Gamma particle-particle singlet
 

--- a/c++/lattice/eliashberg.hpp
+++ b/c++/lattice/eliashberg.hpp
@@ -47,6 +47,7 @@ namespace tprf {
   gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
   gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk);
   gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk);
+  std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_and_constant(chi_wk_vt Gamma_pp);
 
  /** Gamma particle-particle singlet
 

--- a/c++/types.hpp
+++ b/c++/types.hpp
@@ -91,6 +91,14 @@ typedef gf<cartesian_product<imfreq, brillouin_zone>, tensor_valued<4>> chi_wk_t
 typedef chi_wk_t::const_view_type chi_wk_cvt;
 typedef chi_wk_t::view_type chi_wk_vt;
 
+typedef gf<brillouin_zone, tensor_valued<4>> chi_k_t;
+typedef chi_k_t::const_view_type chi_k_cvt;
+typedef chi_k_t::view_type chi_k_vt;
+
+typedef gf<cyclic_lattice, tensor_valued<4>> chi_r_t;
+typedef chi_r_t::const_view_type chi_r_cvt;
+typedef chi_r_t::view_type chi_r_vt;
+
     // -- back to old style
 
 typedef gf<cartesian_product<brillouin_zone, imfreq, imfreq, imfreq>, tensor_valued<4>> chiq_t;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,6 +5,7 @@ from recommonmark.parser import CommonMarkParser
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon'
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -22,6 +22,7 @@ Reference manual
 
    reference/linalg
    reference/lattice
+   reference/eliashberg
 
 Theory and notation
 -------------------

--- a/doc/reference/eliashberg.rst
+++ b/doc/reference/eliashberg.rst
@@ -1,0 +1,8 @@
+.. highlight:: python
+
+.. _eliashberg_functions: 
+
+Eliashberg
+==========
+
+.. autofunction:: triqs_tprf.eliashberg.solve_eliashberg_fft

--- a/doc/reference/lattice.rst
+++ b/doc/reference/lattice.rst
@@ -36,6 +36,7 @@
   :maxdepth: 1
 
   /cpp2doc_generated/tprf/eliashberg_product
+  /cpp2doc_generated/tprf/eliashberg_product_fft
   /cpp2doc_generated/tprf/gamma_PP_singlet
   /cpp2doc_generated/tprf/gamma_PP_triplet
 

--- a/python/eliashberg.py
+++ b/python/eliashberg.py
@@ -49,6 +49,14 @@ def solve_eliashberg(Gamma_pp, g_wk, tol=1e-10):
         delta_out_x = from_wk_to_x(delta_out_wk)
         return delta_out_x
 
+    # -- Check if the constant term of Gamma_pp is given, if not determine it
+    # CODECODECODECODECODECODECODECODECODECODECODECODECODECODECODE
+
+    # -- Fourier transform the dynamic term in tau and r space and the constant term to r space
+    # CODECODECODECODECODECODECODECODECODECODECODECODECODECODECODE
+
+    # -- The Eliashberg product will take care of the rest
+
     x = from_wk_to_x(g_wk)
     N = x.shape[0]
     linop = LinearOperator(matvec=matvec, dtype=np.complex, shape=(N, N))

--- a/python/eliashberg.py
+++ b/python/eliashberg.py
@@ -27,6 +27,8 @@ from scipy.sparse.linalg import eigs
 # ----------------------------------------------------------------------
 
 from lattice import eliashberg_product
+from lattice import eliashberg_product_fft
+from lattice import split_into_dynamic_wk_and_constant_k, dynamic_and_constant_to_tr
 
 # ----------------------------------------------------------------------
 def solve_eliashberg(Gamma_pp, g_wk, tol=1e-10):
@@ -49,13 +51,62 @@ def solve_eliashberg(Gamma_pp, g_wk, tol=1e-10):
         delta_out_x = from_wk_to_x(delta_out_wk)
         return delta_out_x
 
-    # -- Check if the constant term of Gamma_pp is given, if not determine it
-    # CODECODECODECODECODECODECODECODECODECODECODECODECODECODECODE
+    x = from_wk_to_x(g_wk)
+    N = x.shape[0]
+    linop = LinearOperator(matvec=matvec, dtype=np.complex, shape=(N, N))
 
-    # -- Fourier transform the dynamic term in tau and r space and the constant term to r space
-    # CODECODECODECODECODECODECODECODECODECODECODECODECODECODECODE
+    np.random.seed(1337)
+    v0 = np.random.random(N)
+    E, U = eigs(linop, which='LR', tol=tol, v0=v0)
 
-    # -- The Eliashberg product will take care of the rest
+    eigen_modes = []
+    for idx in xrange(U.shape[-1]):
+        delta_wk = from_x_to_wk(U[:, idx])
+        eigen_modes.append(delta_wk)
+
+    return E, eigen_modes
+    
+def solve_eliashberg_fft(Gamma_pp, g_wk, Gamma_pp_const_k=None, tol=1e-10):
+
+    """ Solve the linearized Eliashberg equation using 
+    iterative eigenvalue algorithms from scipy via the FFT product
+    
+    Parmeters:
+
+        Gamma_pp : gf object, pairing vertex
+        g_wk : gf object, Green's function
+        Gamma_pp_const_k : int, float, np.ndarray, part of the pairing vertex that is constant
+                            in Matsubara frequency space
+        tol : float, relative accuracy for eigenvalues (stopping criterion)
+    """
+
+    # -- Determine the dynamic and constant part via a tail fit
+    # -- (This is done even if the constant term is given to get the specific GF types)
+    Gamma_pp_dyn_wk_fit, Gamma_pp_const_k_fit = split_into_dynamic_wk_and_constant_k(Gamma_pp)
+
+    # -- Use a the constant term if explicitly given
+    if Gamma_pp_const_k:
+        Gamma_pp_const_k_fit.data[:] = Gamma_pp_const_k
+        Gamma_pp_dyn_wk_fit.data[:] = Gamma_pp.data - Gamma_pp_const_k
+
+    # -- FFT dynamic and constant term to (tau, real) or (real)
+    Gamma_pp_dyn_tr, Gamma_pp_const_r = dynamic_and_constant_to_tr(Gamma_pp_dyn_wk_fit, 
+                                                                    Gamma_pp_const_k_fit)
+    
+    def from_x_to_wk(delta_x):
+        delta_wk = g_wk.copy()
+        delta_wk.data[:] = delta_x.reshape(delta_wk.data.shape)
+        return delta_wk
+
+    def from_wk_to_x(delta_wk):
+        delta_x = delta_wk.data.copy().flatten()
+        return delta_x
+    
+    def matvec(delta_x):
+        delta_wk = from_x_to_wk(delta_x)
+        delta_out_wk = eliashberg_product_fft(Gamma_pp_dyn_tr, Gamma_pp_const_r, g_wk, delta_wk)
+        delta_out_x = from_wk_to_x(delta_out_wk)
+        return delta_out_x
 
     x = from_wk_to_x(g_wk)
     N = x.shape[0]

--- a/python/lattice_desc.py
+++ b/python/lattice_desc.py
@@ -64,6 +64,8 @@ module.add_function("chi_wk_t solve_rpa_PH(chi_wk_vt chi0, array_view<std::compl
 # -- Eliashberg
 
 module.add_function("gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
+module.add_function("gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
+module.add_function("gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
 module.add_function("chi_wk_t gamma_PP_singlet(chi_wk_vt chi_c, chi_wk_vt chi_s, array_view<std::complex<double>, 4> U_c, array_view<std::complex<double>, 4> U_s)", doc = """""")
 
 # -- Full BSE functions

--- a/python/lattice_desc.py
+++ b/python/lattice_desc.py
@@ -64,9 +64,10 @@ module.add_function("chi_wk_t solve_rpa_PH(chi_wk_vt chi0, array_view<std::compl
 # -- Eliashberg
 
 module.add_function("gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
-module.add_function("gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
+module.add_function("gk_iw_t eliashberg_product_fft(chi_tr_vt Gamma_pp_dyn_tr, chi_r_vt Gamma_pp_const_r, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
 module.add_function("gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
-module.add_function("std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_and_constant(chi_wk_vt Gamma_pp)", doc = """""")
+module.add_function("std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_wk_and_constant_k(chi_wk_vt Gamma_pp)", doc = """""")
+module.add_function("std::tuple<chi_tr_vt, chi_r_vt> dynamic_and_constant_to_tr(chi_wk_vt Gamma_pp_dyn_wk, chi_k_vt Gamma_pp_const_k)", doc = """""")
 module.add_function("chi_wk_t gamma_PP_singlet(chi_wk_vt chi_c, chi_wk_vt chi_s, array_view<std::complex<double>, 4> U_c, array_view<std::complex<double>, 4> U_s)", doc = """""")
 
 # -- Full BSE functions

--- a/python/lattice_desc.py
+++ b/python/lattice_desc.py
@@ -66,6 +66,7 @@ module.add_function("chi_wk_t solve_rpa_PH(chi_wk_vt chi0, array_view<std::compl
 module.add_function("gk_iw_t eliashberg_product(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
 module.add_function("gk_iw_t eliashberg_product_fft(chi_wk_vt Gamma_pp, gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
 module.add_function("gk_iw_t eliashberg_g_delta_g_product(gk_iw_vt g_wk, gk_iw_vt delta_wk)", doc = """""")
+module.add_function("std::tuple<chi_wk_vt, chi_k_vt> split_into_dynamic_and_constant(chi_wk_vt Gamma_pp)", doc = """""")
 module.add_function("chi_wk_t gamma_PP_singlet(chi_wk_vt chi_c, chi_wk_vt chi_s, array_view<std::complex<double>, 4> U_c, array_view<std::complex<double>, 4> U_s)", doc = """""")
 
 # -- Full BSE functions

--- a/test/python/eliashberg_fft.py
+++ b/test/python/eliashberg_fft.py
@@ -1,0 +1,146 @@
+# ----------------------------------------------------------------------
+
+""" Compare final result and between steps of the Eliashberg equation to
+previous erstablished results """
+
+# ----------------------------------------------------------------------
+
+import numpy as np
+
+# ----------------------------------------------------------------------
+
+from triqs_tprf.ParameterCollection import ParameterCollection
+from pytriqs.gf import Gf, MeshImFreq, Idx
+
+from triqs_tprf.tight_binding import TBLattice
+
+from triqs_tprf.lattice import lattice_dyson_g0_wk, solve_rpa_PH
+from triqs_tprf.lattice_utils import imtime_bubble_chi0_wk
+from triqs_tprf.lattice import gamma_PP_singlet
+from triqs_tprf.lattice import eliashberg_product
+from triqs_tprf.lattice import eliashberg_product_fft
+from triqs_tprf.lattice import eliashberg_g_delta_g_product
+from triqs_tprf.eliashberg import solve_eliashberg
+
+# ----------------------------------------------------------------------
+
+from utilities import read_TarGZ_HDFArchive
+
+# ----------------------------------------------------------------------
+
+# -- Read previous established results
+
+import os
+os.system('pwd')
+
+filename = './eliashberg_benchmark.tar.gz'
+p = read_TarGZ_HDFArchive(filename)['p']
+
+print('\nThe benchmark data was obtained with the version of hash %s.'%p.tprf_hash)
+
+
+t = - 2.0 * np.eye(1)
+t_r = TBLattice(
+    units = [(1, 0, 0)],
+    hopping = {
+        (+1,): t,
+        (-1,): t,
+        },
+    orbital_positions = [(0,0,0)],
+    orbital_names = ['up', 'do'],
+    )
+
+e_k = t_r.on_mesh_brillouin_zone((4, 1, 1))
+print e_k.data
+print p.e_k.data
+
+#np.testing.assert_allclose(e_k.data, p.e_k.data)
+
+# -- Test the construction of Gamma
+
+gamma = gamma_PP_singlet(p.chi_c, p.chi_s, p.U_c, p.U_s)
+np.testing.assert_allclose(gamma.data, p.gamma.data)
+
+# -- Construct a Gamma with a possibly different wmesh than the benchmark data
+
+print p.nw_gf
+print p.nw_chi0
+
+factor = 1.
+
+wmesh = MeshImFreq(beta=p.beta, S='Fermion', n_max=int(factor*p.nw_gf))
+#g0_wk = lattice_dyson_g0_wk(mu=p.mu, e_k=p.e_k, mesh=wmesh)
+g0_wk = lattice_dyson_g0_wk(mu=p.mu, e_k=e_k, mesh=wmesh)
+
+wmesh_big = MeshImFreq(beta=p.beta, S='Fermion', n_max=int(2*factor*p.nw_gf))
+g0_wk_big = lattice_dyson_g0_wk(mu=p.mu, e_k=e_k, mesh=wmesh_big)
+
+#np.testing.assert_allclose(g0_wk.data, p.g0_wk.data)
+
+#chi00_wk = imtime_bubble_chi0_wk(g0_wk_big, nw=int(factor*p.nw_chi0))
+chi00_wk = imtime_bubble_chi0_wk(g0_wk_big, nw=int(2*factor*p.nw_gf + 1))
+#chi00_wk = imtime_bubble_chi0_wk(g0_wk, nw=int(2*factor*p.nw_gf + 1))
+
+print g0_wk.data.shape
+print chi00_wk.data.shape
+#exit()
+
+chi_s = solve_rpa_PH(chi00_wk, +p.U_s)
+chi_c = solve_rpa_PH(chi00_wk, -p.U_c) # Minus for correct charge rpa equation
+
+gamma = gamma_PP_singlet(chi_c, chi_s, p.U_c, p.U_s)
+
+# -- Test the Eliashberg equation with the new gamma
+
+F_wk = eliashberg_g_delta_g_product(g0_wk, g0_wk)
+next_delta = eliashberg_product(gamma, g0_wk, g0_wk)
+next_delta_fft = eliashberg_product_fft(gamma, g0_wk, g0_wk)
+
+from pytriqs.plot.mpl_interface import oplot, plt
+subp = [3, 3, 1]
+plt.figure(figsize=(9, 6))
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(g0_wk[:, Idx(0, 0, 0)], label='d')
+plt.title('g0_wk')
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(chi00_wk[:, Idx(0, 0, 0)], label='d')
+plt.title('chi00_wk')
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(gamma[:, Idx(0, 0, 0)], label='d')
+plt.title('gamma')
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(F_wk[:, Idx(0, 0, 0)])
+plt.title('F_wk')
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(next_delta[:, Idx(0, 0, 0)], label='d')
+plt.title('next_delta')
+
+plt.subplot(*subp); subp[-1] += 1
+oplot(next_delta_fft[:, Idx(0, 0, 0)], label='dfft')
+plt.title('next_delta_fft')
+
+plt.tight_layout()
+plt.show(); exit()
+
+
+print next_delta.data[:4, 0, 0, 0]
+print next_delta_fft.data[:4, 0, 0, 0]
+
+exit()
+
+Es, eigen_modes = solve_eliashberg(gamma, g0_wk)
+
+np.testing.assert_allclose(next_delta.data, p.next_delta.data, atol=1e-7)
+
+np.testing.assert_allclose(Es[0], p.E)
+try:
+    np.testing.assert_allclose(eigen_modes[0].data, p.eigen_mode.data, atol=1e-6)
+except AssertionError:
+    np.testing.assert_allclose(-eigen_modes[0].data, p.eigen_mode.data, atol=1e-6)
+
+print('\nSame results for both versions.')

--- a/test/python/eliashberg_fft.py
+++ b/test/python/eliashberg_fft.py
@@ -20,8 +20,9 @@ from triqs_tprf.lattice import gamma_PP_singlet
 from triqs_tprf.lattice import eliashberg_product
 from triqs_tprf.lattice import eliashberg_product_fft
 from triqs_tprf.lattice import eliashberg_g_delta_g_product
-from triqs_tprf.lattice import split_into_dynamic_and_constant
-from triqs_tprf.eliashberg import solve_eliashberg
+from triqs_tprf.lattice import split_into_dynamic_wk_and_constant_k
+from triqs_tprf.lattice import dynamic_and_constant_to_tr
+from triqs_tprf.eliashberg import solve_eliashberg, solve_eliashberg_fft
 from triqs_tprf.rpa_tensor import kanamori_charge_and_spin_quartic_interaction_tensors
 
 # ----------------------------------------------------------------------
@@ -35,8 +36,8 @@ from utilities import read_TarGZ_HDFArchive
 import os
 os.system('pwd')
 
-nk = 16
-nw = 200
+nk = 4
+nw = 1000
 beta = 5
 mu = 0.0
 U = 1.0
@@ -75,7 +76,8 @@ chi_c = solve_rpa_PH(chi00_wk, -U_c) # Minus for correct charge rpa equation
 
 gamma = gamma_PP_singlet(chi_c, chi_s, U_c, U_s)
 
-gamma_dyn, gamma_const = split_into_dynamic_and_constant(gamma)
+gamma_dyn_wk, gamma_const_k = split_into_dynamic_wk_and_constant_k(gamma)
+gamma_dyn_tr, gamma_const_r = dynamic_and_constant_to_tr(gamma_dyn_wk, gamma_const_k)
 
 # -- Test the Eliashberg equation with the new gamma
 
@@ -84,57 +86,77 @@ delta.data[:] = 1.0
 
 F_wk = eliashberg_g_delta_g_product(g0_wk, delta)
 next_delta = eliashberg_product(gamma, g0_wk, delta)
-next_delta_fft = eliashberg_product_fft(gamma, g0_wk, delta)
+next_delta_fft = eliashberg_product_fft(gamma_dyn_tr, gamma_const_r, g0_wk, delta)
+
+
+print(np.allclose(next_delta.data, next_delta_fft.data))
+print(np.max(np.abs((next_delta.data - next_delta_fft.data))))
+
+delta_init = g0_wk.copy()
+delta_init.data[:] = np.random.random(g0_wk.data.shape) 
+delta_init.data[:] = 1.0
+
+#next_delta = eliashberg_product_fft(gamma_dyn_tr, gamma_const_r, g0_wk, delta_init)
+#for i in range(100):
+#    next_delta = eliashberg_product_fft(gamma_dyn_tr, gamma_const_r, g0_wk, next_delta)
+
+
+
 
 
 k_point = Idx(0, 0, 0)
 
-print(np.allclose(next_delta[:, k_point].data, next_delta_fft[:, k_point].data))
-print(np.max(np.abs((next_delta[:, k_point].data - next_delta_fft[:, k_point].data))))
 
 
-from pytriqs.plot.mpl_interface import oplot, plt
-subp = [3, 3, 1]
-plt.figure(figsize=(9, 6))
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(g0_wk[:, k_point], label='d')
-plt.title('g0_wk')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(chi00_wk[:, k_point], label='d')
-plt.title('chi00_wk')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(gamma[:, k_point], label='d')
-plt.title('gamma')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(gamma_dyn[:, k_point], label='d')
-plt.title('gamma_dyn')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(F_wk[:, k_point])
-plt.title('F_wk')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(next_delta[:, k_point], label='d')
-plt.title('next_delta')
-
-plt.subplot(*subp); subp[-1] += 1
-oplot(next_delta_fft[:, k_point], label='dfft')
-plt.title('next_delta_fft')
-
-plt.tight_layout()
-plt.show(); exit()
+#from pytriqs.plot.mpl_interface import oplot, plt
+#subp = [3, 3, 1]
+#plt.figure(figsize=(9, 6))
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(g0_wk[:, k_point], label='d')
+#plt.title('g0_wk')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(chi00_wk[:, k_point], label='d')
+#plt.title('chi00_wk')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(gamma[:, k_point], label='d')
+#plt.title('gamma')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(gamma_dyn_tr[:, k_point], label='d')
+#plt.title('gamma_dyn')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(F_wk[:, k_point])
+#plt.title('F_wk')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(next_delta[:, k_point], label='d')
+#plt.title('next_delta')
+#
+#plt.subplot(*subp); subp[-1] += 1
+#oplot(next_delta_fft[:, k_point], label='dfft')
+#plt.title('next_delta_fft')
+#
+#plt.tight_layout()
+#plt.show()
 
 
 print next_delta.data[:4, 0, 0, 0]
 print next_delta_fft.data[:4, 0, 0, 0]
 
-exit()
-
 Es, eigen_modes = solve_eliashberg(gamma, g0_wk)
+Es_fft, eigen_modes_fft = solve_eliashberg_fft(gamma, g0_wk, 1.0)
+Es_fft2, eigen_modes_fft2 = solve_eliashberg_fft(gamma, g0_wk)
+
+print(Es)
+print(Es_fft)
+print(Es_fft2)
+
+
+exit()
 
 np.testing.assert_allclose(next_delta.data, p.next_delta.data, atol=1e-7)
 


### PR DESCRIPTION
This PR merges the FFT implementation of the eliashberg equation into the main branch of the eliashberg equation.

The FFT implementation gives the same results as the naive one but is far more computational efficient.
The only downside of the FFT implementation is the arise of the warning
```
WARNING: Direct Fourier cannot deduce the high-frequency moments of G(tau) due to noise or a coarse tau-grid. 	  Please specify the high-frequency moments for higher accuracy.
``` 
For a high enough w-mesh these warnings do not occur, but even if they do the results are on top with the naive implementation.
Still these warnings should be controlled before the FFT implementation can substitute the naive one.


